### PR TITLE
Fix for `Tag#dom_class_name_for`

### DIFF
--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -95,7 +95,7 @@ module Arbre
       end
 
       INDENT_SIZE = 2
-      
+
       def indent(open_tag, child_content, close_tag)
         spaces = ' ' * indent_level * INDENT_SIZE
 
@@ -119,11 +119,11 @@ module Arbre
 
         html
       end
-      
+
       def self_closing_tag?
         %w|meta link|.include?(tag_name)
       end
-      
+
       def no_child?
         children.empty?
       end
@@ -149,7 +149,7 @@ module Arbre
         if record.class.respond_to?(:model_name)
           record.class.model_name.singular
         else
-          record.class.underscore.gsub("/", "_")
+          record.class.name.underscore.gsub("/", "_")
         end
       end
 

--- a/spec/arbre/unit/html/tag_spec.rb
+++ b/spec/arbre/unit/html/tag_spec.rb
@@ -32,6 +32,23 @@ describe Arbre::HTML::Tag do
       tag.class_list.should include("resource_class")
     end
 
+
+    describe "for an object that doesn't have a model_name" do
+      let(:resource_class){ mock(:name => 'ResourceClass') }
+
+      before do
+        tag.build :for => resource
+      end
+
+      it "should set the id to the type and id" do
+        tag.id.should == "resource_class_5"
+      end
+
+      it "should add a class name" do
+        tag.class_list.should include("resource_class")
+      end
+    end
+
     describe "with a default_id_for_prefix" do
 
       let(:tag) do


### PR DESCRIPTION
In the less common case when a resource doesn't respond to `#model_name`
`Tag#dom_class_name_for` previously called `#underscore` on the class.

I've changed this to call `#underscore` on the class name as
`#underscore` is a standard (`ActiveSupport`) method on `String` but not
on `Class`.
