### PR TITLE
Don't use default separator

### DIFF
--- a/lib/arbre/element_collection.rb
+++ b/lib/arbre/element_collection.rb
@@ -18,7 +18,7 @@ module Arbre
     def to_s
       self.collect do |element|
         element.to_s
-      end.join.html_safe
+      end.join('').html_safe
     end
   end
 

--- a/spec/arbre/unit/element_spec.rb
+++ b/spec/arbre/unit/element_spec.rb
@@ -164,9 +164,22 @@ describe Arbre::Element do
 
   describe "rendering to html" do
 
+    before  { @separator = $, }
+    after   { $, = @separator }
+    let(:collection){ element + "hello world" }
+
     it "should render the children collection" do
       element.children.should_receive(:to_s).and_return("content")
       element.to_s.should == "content"
+    end
+
+    it "should render collection when is set the default separator" do
+      $, = "_"
+      collection.to_s.should == "hello world"
+    end
+
+    it "should render collection when is not set the default separator" do
+      collection.to_s.should == "hello world"
     end
 
   end


### PR DESCRIPTION
When default separator is set then the collection renders incorrectly

``` ruby
$, = "_"
collection.to_s # => 1_2
```
