### PR TITLE
FIX: Prevent syntax errors when having a comment block at the end of a view

### DIFF
--- a/lib/arbre/rails/template_handler.rb
+++ b/lib/arbre/rails/template_handler.rb
@@ -1,14 +1,14 @@
 module Arbre
   module Rails
-
     class TemplateHandler
-
       def call(template)
-        "Arbre::Context.new(assigns, self){ #{template.source} }.to_s"
+        <<-END
+        Arbre::Context.new(assigns, self) {
+          #{template.source}
+        }.to_s
+        END
       end
-
     end
-
   end
 end
 


### PR DESCRIPTION
Example:

```
strong("Hello")
# this is a comment
```

The template handler compiles it as:

```
Arbre::Context.new(assigns, self) { strong("Hello") 
# this is a comment }
```

wich shadows the closing bracket of the block
