### PR TITLE
make `Element#inspect` behave correctly in Ruby 2.0

### DIFF
--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -128,6 +128,10 @@ module Arbre
     def each(&block)
       [to_s].each(&block)
     end
+    
+    def inspect
+      to_s
+    end
 
     def to_str
       to_s


### PR DESCRIPTION
As of ruby/ruby@fd7dc23d281f, `Kernel#inspect` no longer uses `to_s` if it's defined.
This means that if `Element#inspect` is called, you'll currently get every instance
variable printed out instead of the expected HTML.

This is causing serious issues for Active Admin when combined with `better_errors`: https://github.com/gregbell/active_admin/issues/2434

Other references:
- https://bugs.ruby-lang.org/issues/6130
- https://github.com/charliesome/better_errors/issues/134
- https://github.com/charliesome/better_errors/issues/200
