### PR TITLE
Interminable #inspect in Context

### DIFF
--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -156,7 +156,7 @@ module Arbre
     alias_method :to_a, :to_ary
 
     def inspect
-      "#<#{self.class}: #{tag_name}>" end
+      "#<#{self.class}: #{tag_name}>"
     end
 
     private


### PR DESCRIPTION
https://github.com/gregbell/arbre/blob/master/lib/arbre/context.rb#L90

is generating interminable (infinite?) inspect output that pushes the server's cpu to 100% enough time that I end up force killing it, I suggest implementing a custom `#inspect` or removing it from the error message.

(third option is a custom error class with an attributes that will store the context for inspection of an eventual `rescue` down the line)
