### PR TITLE
All void elements should be self-closing

### DIFF
--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -5,13 +5,14 @@ module Arbre
                        :bdo, :blockquote, :body, :br, :button, :canvas, :caption, :cite,
                        :code, :col, :colgroup, :command, :datalist, :dd, :del, :details,
                        :dfn, :div, :dl, :dt, :em, :embed, :fieldset, :figcaption, :figure,
-                       :footer, :form, :h1, :h2, :h3, :h4, :h5, :h6, :head, :header, :hgroup, 
-                       :hr, :html, :i, :iframe, :img, :input, :ins, :keygen, :kbd, :label, 
-                       :legend, :li, :link, :map, :mark, :menu, :meta, :meter, :nav, :noscript, 
-                       :object, :ol, :optgroup, :option, :output, :pre, :progress, :q,
-                       :s, :samp, :script, :section, :select, :small, :source, :span,
-                       :strong, :style, :sub, :summary, :sup, :table, :tbody, :td,
-                       :textarea, :tfoot, :th, :thead, :time, :title, :tr, :ul, :var, :video ]
+                       :footer, :form, :h1, :h2, :h3, :h4, :h5, :h6, :head, :header, :hgroup,
+                       :hr, :html, :i, :iframe, :img, :input, :ins, :keygen, :kbd, :label,
+                       :legend, :li, :link, :map, :mark, :menu, :menuitem, :meta, :meter, :nav,
+                       :noscript, :object, :ol, :optgroup, :option, :output, :param, :pre,
+                       :progress, :q, :s, :samp, :script, :section, :select, :small, :source,
+                       :span, :strong, :style, :sub, :summary, :sup, :table, :tbody, :td,
+                       :textarea, :tfoot, :th, :thead, :time, :title, :tr, :track, :ul, :var,
+                       :video, :wbr ]
 
     HTML5_ELEMENTS = [ :p ] + AUTO_BUILD_ELEMENTS
 

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -6,6 +6,9 @@ module Arbre
     class Tag < Element
       attr_reader :attributes
 
+      # See: http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
+      SELF_CLOSING_TAGS = %w|area base br col embed hr img input keygen link menuitem meta param source track wbr|
+
       def initialize(*)
         super
         @attributes = Attributes.new
@@ -130,7 +133,7 @@ module Arbre
       end
 
       def self_closing_tag?
-        %w|br hr link meta|.include?(tag_name)
+        SELF_CLOSING_TAGS.include?(tag_name)
       end
 
       def no_child?

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -187,16 +187,12 @@ HTML
       }.to_s).to eq("<link rel=\"stylesheet\"/>\n")
     end
 
-    it "should self-close hr tags" do
-      expect(arbre {
-        hr
-      }.to_s).to eq("<hr/>\n")
-    end
-
-    it "should self-close br tags" do
-      expect(arbre {
-        br
-      }.to_s).to eq("<br/>\n")
+    (Arbre::HTML::Tag::SELF_CLOSING_TAGS - %w|script meta link|).each do |tag|
+      it "should self-close #{tag} tags" do
+        expect(arbre {
+          send(tag, {})
+        }.to_s).to eq("<#{tag}/>\n")
+      end
     end
 
   end


### PR DESCRIPTION
According to the HTML5 specification hr elements should not have an end tag.
http://www.w3.org/TR/html5/grouping-content.html#the-hr-element
