### PR TITLE
Use correct way to respond_to

### DIFF
--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -67,8 +67,8 @@ module Arbre
     end
     alias :length :bytesize
 
-    def respond_to?(method)
-      super || cached_html.respond_to?(method)
+    def respond_to_missing?(method, include_all)
+      super || cached_html.respond_to?(method, include_all)
     end
 
     # Webservers treat Arbre::Context as a string. We override

--- a/lib/arbre/rails/forms.rb
+++ b/lib/arbre/rails/forms.rb
@@ -16,8 +16,8 @@ module Arbre
           proxy_call_to_form :select, *args
         end
 
-        def respond_to?(name)
-          if form_builder && form_builder.respond_to?(name)
+        def respond_to_missing?(method, include_all)
+          if form_builder && form_builder.respond_to?(method, include_all)
             true
           else
             super


### PR DESCRIPTION
Hi,

It's the same as the PR in [active_admin](https://github.com/activeadmin/activeadmin/pull/3317) gem.
We should use `respond_to_missing?` instead of `respond_to?`.
