### PR TITLE
Add <svg> element.

### DIFF
--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -10,7 +10,7 @@ module Arbre
                        :legend, :li, :link, :map, :mark, :menu, :meta, :meter, :nav, :noscript, 
                        :object, :ol, :optgroup, :option, :output, :pre, :progress, :q,
                        :s, :samp, :script, :section, :select, :small, :source, :span,
-                       :strong, :style, :sub, :summary, :sup, :table, :tbody, :td,
+                       :strong, :style, :sub, :summary, :sup, :svg, :table, :tbody, :td,
                        :textarea, :tfoot, :th, :thead, :time, :title, :tr, :ul, :var, :video ]
 
     HTML5_ELEMENTS = [ :p ] + AUTO_BUILD_ELEMENTS


### PR DESCRIPTION
It looks like :svg was missing from this list. It probably doesn't come up
much, but we had a use for it, so I figured I should PR it back upstream.
