### PR TITLE
Tag option `for` sets the attribute when value is a string or symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased [☰](https://github.com/activeadmin/arbre/compare/v1.0.3...master)
 
+* Tag option `for` sets the attribute when value is a string or symbol [#18]
+
 ## 1.0.3 [☰](https://github.com/activeadmin/arbre/compare/v1.0.2...v1.0.3)
 
 * Performance improvements [#40][] by [@alexesDev][]

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -20,7 +20,10 @@ module Arbre
         attributes = extract_arguments(args)
         self.content = args.first if args.first
 
-        set_for_attribute(attributes.delete(:for))
+        for_value = attributes[:for]
+        unless for_value.is_a?(String) || for_value.is_a?(Symbol)
+          set_for_attribute(attributes.delete(:for))
+        end
 
         attributes.each do |key, value|
           set_attribute(key, value)

--- a/spec/arbre/unit/html/tag_spec.rb
+++ b/spec/arbre/unit/html/tag_spec.rb
@@ -66,6 +66,18 @@ describe Arbre::HTML::Tag do
     end
   end
 
+  describe "creating a tag with a for attribute" do
+    it "sets the `for` attribute when a string is given" do
+      tag.build for: "email"
+      expect(tag.attributes[:for]).to eq "email"
+    end
+
+    it "sets the `for` attribute when a symbol is given" do
+      tag.build for: :email
+      expect(tag.attributes[:for]).to eq :email
+    end
+  end
+
   describe "css class names" do
 
     it "should add a class" do


### PR DESCRIPTION
We didn't change the option to avoid a breaking change. If changing the usage of for should change completely, a deprecation warning can easily be shown. This gets labels working fine at least.

fixes #18