### PR TITLE
Use symbolize_keys! to reduce object allocation

### DIFF
--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -35,8 +35,8 @@ module Arbre
     #
     # @yield [] The block that will get instance eval'd in the context
     def initialize(assigns = {}, helpers = nil, &block)
-      assigns = assigns || {}
-      @_assigns = assigns.symbolize_keys
+      assigns = (assigns || {}).symbolize_keys!
+      @_assigns = assigns
 
       @_helpers = helpers
       @_current_arbre_element_buffer = [self]


### PR DESCRIPTION

[Benchmark script here](https://gist.github.com/jamescook/eb215e584b85f66b244a21c8a114acca)
```
ruby arbre_context_bench.rb && SECOND_RUN=y ruby arbre_context_bench.rb
```

Results
```
Warming up --------------------------------------
context w/ symbolize_keys
                        29.342k i/100ms
Calculating -------------------------------------
context w/ symbolize_keys
                        356.949k (± 4.9%) i/s -      1.790M

Pausing here -- run Ruby again to measure the next benchmark...
Warming up --------------------------------------
context w/ symbolize_keys!
                        31.483k i/100ms
Calculating -------------------------------------
context w/ symbolize_keys!
                        429.136k (± 4.4%) i/s -      2.172M

Comparison:
context w/ symbolize_keys!:   429136.5 i/s
context w/ symbolize_keys:   356949.0 i/s - 1.20x slower
```