### PR TITLE
Lazily allocate ElementCollection

### DIFF
--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -8,11 +8,14 @@ module Arbre
     include BuilderMethods
 
     attr_accessor :parent
-    attr_reader :children, :arbre_context
+    attr_reader :arbre_context
 
     def initialize(arbre_context = Arbre::Context.new)
       @arbre_context = arbre_context
-      @children = ElementCollection.new
+    end
+
+    def children
+      @children ||= ElementCollection.new
     end
 
     def assigns
@@ -37,7 +40,7 @@ module Arbre
 
       if child.is_a?(Array)
         child.each{|item| add_child(item) }
-        return @children
+        return children
       end
 
       # If its not an element, wrap it in a TextNode
@@ -52,12 +55,12 @@ module Arbre
         child.parent = self
       end
 
-      @children << child
+      children << child
     end
 
     def remove_child(child)
       child.parent = nil if child.respond_to?(:parent=)
-      @children.delete(child)
+      children.delete(child)
     end
 
     def <<(child)
@@ -65,7 +68,7 @@ module Arbre
     end
 
     def children?
-      @children.any?
+      @children && children.any?
     end
 
     def parent=(parent)
@@ -160,7 +163,7 @@ module Arbre
 
     # Resets the Elements children
     def clear_children!
-      @children.clear
+      children.clear
     end
 
     # Implements the method lookup chain. When you call a method that


### PR DESCRIPTION
Not all `Element` instances will have child elements.

[Benchmark script here](https://gist.github.com/jamescook/16a274c36c4b490a68f9ba54937880da)

```
ruby arbre_element_bench.rb && SECOND_RUN=y ruby arbre_element_bench.rb
```

Benchmark results:
```
Warming up --------------------------------------
element w/ ElementCollection
                        88.462k i/100ms
Calculating -------------------------------------
element w/ ElementCollection
                          2.246M (± 6.6%) i/s -     11.235M

Pausing here -- run Ruby again to measure the next benchmark...
Warming up --------------------------------------
element w/o ElementCollection
                       115.486k i/100ms
Calculating -------------------------------------
element w/o ElementCollection
                          3.655M (± 5.0%) i/s -     18.247M

Comparison:
element w/o ElementCollection:  3654569.6 i/s
element w/ ElementCollection:  2245577.6 i/s - 1.63x slower
```