### PR TITLE
Fix warnings when running in verbose mode

### DIFF
--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -42,7 +42,7 @@ module Arbre
       @_current_arbre_element_buffer = [self]
 
       super(self)
-      instance_eval &block if block_given?
+      instance_eval(&block) if block_given?
     end
 
     def arbre_context

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -7,12 +7,13 @@ module Arbre
   class Element
     include BuilderMethods
 
-    attr_accessor :parent
+    attr_reader :parent
     attr_reader :children, :arbre_context
 
     def initialize(arbre_context = Arbre::Context.new)
       @arbre_context = arbre_context
       @children = ElementCollection.new
+      @parent = nil
     end
 
     def assigns


### PR DESCRIPTION
The following warnings will be fixed:

/lib/arbre/context.rb:45: warning: `&' interpreted as argument prefix
/lib/arbre/element.rb:71: warning: method redefined; discarding old parent=
/lib/arbre/element.rb:76: warning: instance variable @parent not initialized