### PR TITLE
Fix build (and drop old rubies support in the process)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ sudo: false
 rvm:
   - 2.4.0
   - jruby-9.1.9.0 # Rails 5.0.2+ requires jruby-9.1.9, see https://github.com/jruby/jruby/issues/4557
+  - jruby-9.1.9.0
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 sudo: false
 rvm:
+  - 2.3.7
   - 2.4.4
+  - 2.5.1
   - jruby-9.1.17.0
+  - jruby-9.2.0.0
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.4.0
-  - jruby-9.1.9.0 # Rails 5.0.2+ requires jruby-9.1.9, see https://github.com/jruby/jruby/issues/4557
-  - jruby-9.1.9.0
+  - 2.4.4
+  - jruby-9.1.17.0
 cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 sudo: false
 rvm:
-  - 2.2.5
   - 2.4.0
   - jruby-9.1.9.0 # Rails 5.0.2+ requires jruby-9.1.9, see https://github.com/jruby/jruby/issues/4557
 cache: bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master (unreleased)
 
+* Drop support for EOL'd rubies (under 2.3) by [@deivid-rodriguez][]
+
 ## 1.1.1 [☰](https://github.com/activeadmin/arbre/compare/v1.1.0...v1.1.1)
 
 * Use mime-types 2.x for Ruby 1.9 by [@timoschilling][]
@@ -67,6 +69,7 @@ Initial release and extraction from Active Admin
 [@LTe]: https://github.com/LTe
 [@OscarBarrett]: https://github.com/OscarBarrett
 [@alexesDev]: https://github.com/alexesDev
+[@deivid-rodriguez]: https://github.com/deivid-rodriguez
 [@dlackty]: https://github.com/dlackty
 [@dtaniwaki]: https://github.com/dtaniwaki
 [@gregbell]: https://github.com/gregbell

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 gem 'mime-types', '~> 2.6', platforms: :ruby_19
 
+gem 'rake'
+
 group :test do
   gem 'rspec'
   gem 'rack'

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -18,5 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
+  s.required_ruby_version = '>= 2.3'
+
   s.add_dependency("activesupport", ">= 3.0.0")
 end


### PR DESCRIPTION
Master build is broken in master, so I'm fixing it here. It was an incompatiblity with development dependencies a ruby 2.2. Since ruby 2.2 is EOL'd, I didn't think too much about it, and drop support, which pairs this repo with AA so I think it's fine.

Also took the chance to bump tested rubies in TravisCI, and added `rake` to the `Gemfile` because `jruby` was not finding it (I guess it's because `rake` is not a default gem there?).