### PR TITLE
Build only protected branches on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,7 @@ rvm:
   - 2.5.1
   - jruby-9.1.17.0
   - jruby-9.2.0.0
+branches:
+  only:
+    - master
 cache: bundler


### PR DESCRIPTION
This is equivalent to activeadmin/activeadmin#5488, for the same reasons stated there. @varyonic are you ok with this, there does not seem to be a lot of downsides and the CI time is cut in half.