### PR TITLE
Add changelog spec to maintain consistency

### DIFF
--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe "Changelog" do
+  subject(:changelog) do
+    path = File.join(File.dirname(__dir__), "CHANGELOG.md")
+    File.read(path)
+  end
+
+  it 'has definitions for all implicit links' do
+    implicit_link_names = changelog.scan(/\[([^\]]+)\]\[\]/).flatten.uniq
+    implicit_link_names.each do |name|
+      expect(changelog).to include("[#{name}]: https")
+    end
+  end
+
+  describe 'entry' do
+    let(:lines) { changelog.each_line }
+
+    subject(:entries) { lines.grep(/^\*/) }
+
+    it 'does not end with a punctuation' do
+      entries.each do |entry|
+        expect(entry).not_to match(/\.$/)
+      end
+    end
+  end
+end

--- a/spec/rails/integration/rendering_spec.rb
+++ b/spec/rails/integration/rendering_spec.rb
@@ -40,6 +40,22 @@ end
 describe TestController, "Rendering with Arbre", type: :request do
   let(:body){ response.body }
 
+  before do
+    Rails.application.routes.draw do
+      get 'test/render_empty', controller: "test"
+      get 'test/render_simple_page', controller: "test"
+      get 'test/render_partial', controller: "test"
+      get 'test/render_erb_partial', controller: "test"
+      get 'test/render_with_instance_variable', controller: "test"
+      get 'test/render_partial_with_instance_variable', controller: "test"
+      get 'test/render_page_with_helpers', controller: "test"
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
   it "should render the empty template" do
     get "/test/render_empty"
     expect(response).to be_successful

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -18,10 +18,6 @@ require 'rails/support/mock_person'
 # Ensure that the rails plugin is installed
 require 'arbre/rails'
 
-Rails.application.routes.draw do
-  get 'test/:action', controller: "test"
-end
-
 module AdditionalHelpers
 
   def protect_against_forgery?


### PR DESCRIPTION
I copied this spec as is from https://github.com/activeadmin/activeadmin/pull/5474 since we follow the same style here. I'm happy to make any additional changes if needed.

Since I had to run the tests there was a single Rails 6 deprecation warning. It was rather easy to solve so I'm including here but can easily move out into a separate PR.