### PR TITLE
Enable rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,12 @@
+---
+
+AllCops:
+  DisabledByDefault: true
+
+  DisplayCopNames: true
+  DisplayStyleGuide: true
+
+  TargetRubyVersion: 2.3
+
+Metrics:
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,3 +10,6 @@ AllCops:
 
 Metrics:
   Enabled: false
+
+Layout/IndentHeredoc:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,10 @@ group :test do
   gem 'pry'
 end
 
+group :tools do
+  gem 'rubocop'
+end
+
 group :rails do
   gem 'rails', '>= 5.0.0.1' # fixes CVE-2016-6316
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,4 +188,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
     arel (9.0.0)
+    ast (2.4.0)
     builder (3.2.3)
     capybara (3.8.0)
       addressable
@@ -74,6 +75,8 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    jaro_winkler (1.5.1)
+    jaro_winkler (1.5.1-java)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -92,6 +95,10 @@ GEM
     nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     nokogiri (1.8.4-java)
+    parallel (1.12.1)
+    parser (2.5.1.2)
+      ast (~> 2.4.0)
+    powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -127,6 +134,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
+    rainbow (3.0.0)
     rake (12.3.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -149,6 +157,15 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    rubocop (0.60.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.0)
     spoon (0.0.6)
       ffi
     sprockets (3.7.2)
@@ -163,6 +180,7 @@ GEM
     thread_safe (0.3.6-java)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unicode-display_width (1.4.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.0-java)
@@ -186,6 +204,7 @@ DEPENDENCIES
   rake
   rspec
   rspec-rails
+  rubocop
 
 BUNDLED WITH
    1.17.1

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,10 @@ Bundler::GemHelper.install_tasks
 require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
-task default: :spec
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
+
+task default: [:spec, :rubocop]
 
 task :console do
   require 'irb'

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -34,11 +34,11 @@ describe Arbre::Component do
   it "should render the object using the builder method name" do
     comp = expect(arbre {
       mock_component
-    }.to_s).to eq <<-HTML
-<div class="mock_component">
-  <h2>Hello World</h2>
-</div>
-HTML
+    }.to_s).to eq <<~HTML
+      <div class="mock_component">
+        <h2>Hello World</h2>
+      </div>
+      HTML
   end
 
 end


### PR DESCRIPTION
Just a minimal config, with only `Layout/IndentHeredoc` enabled. It should fail until #82 is merged and this is rebased on top of it.