### PR TITLE
Fix ActionView deprecation regarding single arity template handlers

### DIFF
--- a/lib/arbre/rails/template_handler.rb
+++ b/lib/arbre/rails/template_handler.rb
@@ -19,10 +19,12 @@ end
 module Arbre
   module Rails
     class TemplateHandler
-      def call(template)
+      def call(template, source = nil)
+        source = template.source unless source
+
         <<-END
         Arbre::Context.new(assigns, self) {
-          #{template.source}
+          #{source}
         }.to_s
         END
       end


### PR DESCRIPTION
Using rails6.0.0.beta2, ActionView gives a deprecation warning regarding single arity template handlers. Template handlers now receive the source directly as a second parameter,

https://github.com/rails/rails/commit/28f88e0074f473f58c2d3fd54cb3daff81027c12

This commit fixes the deprecation warning, while still allowing old version of ActionView to call the template handler with a single parameter.