### PR TITLE
More curated shipped file list

### DIFF
--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.4'

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -13,7 +13,10 @@ Gem::Specification.new do |s|
   s.description = %q{Arbre makes it easy to generate HTML directly in Ruby}
   s.license     = "MIT"
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files LICENSE docs lib`.split("\n")
+
+  s.extra_rdoc_files = %w[CHANGELOG.md README.md]
+
   s.require_paths = ["lib"]
 
   s.required_ruby_version = '>= 2.4'


### PR DESCRIPTION
I noticed that we're shipping unnecessary files with the gem, like the `Gemfile` and `Gemfile.lock` files which are only useful for development.

This PR makes our shipped gem thinner.