### PR TITLE
Drop ruby 2.4 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
   - gem update --system 3.0.6
   - gem install bundler:2.0.2
 rvm:
-  - 2.4.5
   - 2.5.5
   - 2.6.2
   - jruby-9.2.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Master (unreleased)
 
 * Drop ruby 2.3 support. [#152][] by [@deivid-rodriguez][]
+* Drop ruby 2.4 support. [#177][] by [@deivid-rodriguez][]
 
 ## 1.2.1 [☰](https://github.com/activeadmin/arbre/compare/v1.2.0...v1.2.1)
 
@@ -86,6 +87,7 @@ Initial release and extraction from Active Admin
 [#110]: https://github.com/activeadmin/arbre/pull/110
 [#121]: https://github.com/activeadmin/arbre/pull/121
 [#152]: https://github.com/activeadmin/arbre/pull/152
+[#177]: https://github.com/activeadmin/arbre/pull/177
 
 [@aramvisser]: https://github.com/aramvisser
 [@LTe]: https://github.com/LTe

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 2.5'
 
   s.add_dependency("activesupport", ">= 3.0.0", "< 6.1")
 end


### PR DESCRIPTION
Support for ruby 2.4 has ended.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/