### PR TITLE
Fix ruby 2.7 warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Drop ruby 2.3 support. [#152][] by [@deivid-rodriguez][]
 * Drop ruby 2.4 support. [#177][] by [@deivid-rodriguez][]
+* Fix ruby 2.7 kwargs warnings. [#202][] by [@deivid-rodriguez][]
 
 ## 1.2.1 [☰](https://github.com/activeadmin/arbre/compare/v1.2.0...v1.2.1)
 
@@ -88,6 +89,7 @@ Initial release and extraction from Active Admin
 [#121]: https://github.com/activeadmin/arbre/pull/121
 [#152]: https://github.com/activeadmin/arbre/pull/152
 [#177]: https://github.com/activeadmin/arbre/pull/177
+[#202]: https://github.com/activeadmin/arbre/pull/202
 
 [@aramvisser]: https://github.com/aramvisser
 [@LTe]: https://github.com/LTe

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -74,11 +74,21 @@ module Arbre
     # Webservers treat Arbre::Context as a string. We override
     # method_missing to delegate to the string representation
     # of the html.
-    def method_missing(method, *args, &block)
-      if cached_html.respond_to? method
-        cached_html.send method, *args, &block
-      else
-        super
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.a")
+      def method_missing(method, *args, **kwargs, &block)
+        if cached_html.respond_to? method
+          cached_html.send method, *args, **kwargs, &block
+        else
+          super
+        end
+      end
+    else
+      def method_missing(method, *args, &block)
+        if cached_html.respond_to? method
+          cached_html.send method, *args, &block
+        else
+          super
+        end
       end
     end
 

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -172,15 +172,29 @@ module Arbre
     #  3. Call the method on the helper object
     #  4. Call super
     #
-    def method_missing(name, *args, &block)
-      if current_arbre_element.respond_to?(name)
-        current_arbre_element.send name, *args, &block
-      elsif assigns && assigns.has_key?(name)
-        assigns[name]
-      elsif helpers.respond_to?(name)
-        helpers.send(name, *args, &block)
-      else
-        super
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.a")
+      def method_missing(name, *args, **kwargs, &block)
+        if current_arbre_element.respond_to?(name)
+          current_arbre_element.send name, *args, **kwargs, &block
+        elsif assigns && assigns.has_key?(name)
+          assigns[name]
+        elsif helpers.respond_to?(name)
+          helpers.send(name, *args, **kwargs, &block)
+        else
+          super
+        end
+      end
+    else
+      def method_missing(name, *args, &block)
+        if current_arbre_element.respond_to?(name)
+          current_arbre_element.send name, *args, &block
+        elsif assigns && assigns.has_key?(name)
+          assigns[name]
+        elsif helpers.respond_to?(name)
+          helpers.send(name, *args, &block)
+        else
+          super
+        end
       end
     end
 


### PR DESCRIPTION
There's [a gem to get "compatible delegation" working](https://rubygems.org/gems/ruby2_keywords), but it seems overkill to me to introduce a dependency just for this, and we're going to need to update the code anyways once we drop support for ruby 2.6, so I think this is fine.

Closes #167.