### PR TITLE
Use `ruby2_keywords` for the moment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     arbre (1.2.1)
       activesupport (>= 3.0.0, < 6.1)
+      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -190,6 +191,7 @@ GEM
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.5'
 
   s.add_dependency("activesupport", ">= 3.0.0", "< 6.1")
+  s.add_dependency("ruby2_keywords", ">= 0.0.2")
 end

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -1,4 +1,5 @@
 require 'arbre/element'
+require 'ruby2_keywords'
 
 module Arbre
 
@@ -74,21 +75,11 @@ module Arbre
     # Webservers treat Arbre::Context as a string. We override
     # method_missing to delegate to the string representation
     # of the html.
-    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.a")
-      def method_missing(method, *args, **kwargs, &block)
-        if cached_html.respond_to? method
-          cached_html.send method, *args, **kwargs, &block
-        else
-          super
-        end
-      end
-    else
-      def method_missing(method, *args, &block)
-        if cached_html.respond_to? method
-          cached_html.send method, *args, &block
-        else
-          super
-        end
+    ruby2_keywords def method_missing(method, *args, &block)
+      if cached_html.respond_to? method
+        cached_html.send method, *args, &block
+      else
+        super
       end
     end
 

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -1,6 +1,7 @@
 require 'arbre/element/builder_methods'
 require 'arbre/element/proxy'
 require 'arbre/element_collection'
+require 'ruby2_keywords'
 
 module Arbre
 
@@ -172,29 +173,15 @@ module Arbre
     #  3. Call the method on the helper object
     #  4. Call super
     #
-    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.7.a")
-      def method_missing(name, *args, **kwargs, &block)
-        if current_arbre_element.respond_to?(name)
-          current_arbre_element.send name, *args, **kwargs, &block
-        elsif assigns && assigns.has_key?(name)
-          assigns[name]
-        elsif helpers.respond_to?(name)
-          helpers.send(name, *args, **kwargs, &block)
-        else
-          super
-        end
-      end
-    else
-      def method_missing(name, *args, &block)
-        if current_arbre_element.respond_to?(name)
-          current_arbre_element.send name, *args, &block
-        elsif assigns && assigns.has_key?(name)
-          assigns[name]
-        elsif helpers.respond_to?(name)
-          helpers.send(name, *args, &block)
-        else
-          super
-        end
+    ruby2_keywords def method_missing(name, *args, &block)
+      if current_arbre_element.respond_to?(name)
+        current_arbre_element.send name, *args, &block
+      elsif assigns && assigns.has_key?(name)
+        assigns[name]
+      elsif helpers.respond_to?(name)
+        helpers.send(name, *args, &block)
+      else
+        super
       end
     end
 


### PR DESCRIPTION
Without this gem, current `activeadmin` version becomes incompatible with the master branch of `arbre`. It shouldn't be an issue as long as we update `activeadmin`'s code to use keyword arguments everywhere, set a minimum dependency on the next `arbre` and release both gems at the same time, but I think it's easier to be conservative.

So let's use `ruby2_keywords`.