### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 ---
 
+require: rubocop-packaging
+
 AllCops:
   DisabledByDefault: true
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 
 group :tools do
   gem 'rubocop'
+  gem 'rubocop-packaging'
 end
 
 group :release do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,8 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
+    rubocop-packaging (0.1.0)
+      rubocop (>= 0.75.0)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     sawyer (0.8.1)
@@ -235,6 +237,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop
+  rubocop-packaging
 
 BUNDLED WITH
    2.1.4

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = %q{Arbre makes it easy to generate HTML directly in Ruby}
   s.license     = "MIT"
 
-  s.files         = `git ls-files LICENSE docs lib`.split("\n")
+  s.files         = Dir['docs/**/*', 'lib/**/*', 'LICENSE'].reject { |f| File.directory?(f) }
 
   s.extra_rdoc_files = %w[CHANGELOG.md README.md]
 


### PR DESCRIPTION
Avoid using git to produce lists of files. Downstreams often need to build your package in an environment that does not have git (on purpose). Use some pure Ruby alternative, like `Dir` or `Dir.glob`.

Simultaneously, add `rubocop-packaging` as a dependency.

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>