### PR TITLE
Cut 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Master (unreleased)
 
+## 1.3.0 [☰](https://github.com/activeadmin/arbre/compare/v1.2.1...v1.3.0)
+
 * Drop ruby 2.3 support. [#152][] by [@deivid-rodriguez][]
 * Drop ruby 2.4 support. [#177][] by [@deivid-rodriguez][]
-* Fix ruby 2.7 kwargs warnings. [#202][] by [@deivid-rodriguez][]
+* Fix ruby 2.7 kwargs warnings. [#202][] and [#205][] by [@deivid-rodriguez][]
 
 ## 1.2.1 [☰](https://github.com/activeadmin/arbre/compare/v1.2.0...v1.2.1)
 
@@ -90,6 +92,7 @@ Initial release and extraction from Active Admin
 [#152]: https://github.com/activeadmin/arbre/pull/152
 [#177]: https://github.com/activeadmin/arbre/pull/177
 [#202]: https://github.com/activeadmin/arbre/pull/202
+[#205]: https://github.com/activeadmin/arbre/pull/205
 
 [@aramvisser]: https://github.com/aramvisser
 [@LTe]: https://github.com/LTe

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    arbre (1.2.1)
+    arbre (1.3.0)
       activesupport (>= 3.0.0, < 6.1)
       ruby2_keywords (>= 0.0.2)
 

--- a/lib/arbre/version.rb
+++ b/lib/arbre/version.rb
@@ -1,3 +1,3 @@
 module Arbre
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
Let's release an arbre version without ruby 2.7 keyword warnings.

We currently test activeadmin's default branch against arbre's default branch and it shows no warnings. In addition to that, I'll run activeadmin v2.7.0 test suite locally against arbre's default branch to make sure that there's no warnings either against the latest activeadmin release.

Closes #223.