### PR TITLE
Fix CI to run against each Ruby version in matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [2.5.8, 2.6.6, 2.7.1, jruby-9.2.11.1]
+        ruby: [2.5.8, 2.6.6, 2.7.2, jruby-9.2.11.1]
 
     env:
       BUNDLE_PATH: vendor/bundle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.2
+          ruby-version: ${{ matrix.ruby }}
           bundler: none
 
       - name: Install a specific rubygems version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [2.5.8, 2.6.6, 2.7.2, jruby-9.2.11.1]
+        ruby: [2.5.8, 2.6.6, 2.7.2, 3.0.0, jruby-9.2.11.1]
 
     env:
       BUNDLE_PATH: vendor/bundle


### PR DESCRIPTION
I noticed that the Ruby version was hard coded, so despite having a matrix defined, each build for that matrix was actually running against the same, hard coded Ruby version 2.7.2. This fixes that so the matrix value is now used. Since we haven't updated this in awhile I also added Ruby 3.0 to the CI matrix.