### PR TITLE
Add 'main' to HTML5 elements

### DIFF
--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -8,7 +8,7 @@ module Arbre
                        :dfn, :div, :dl, :dt, :em, :embed, :fieldset, :figcaption, :figure,
                        :footer, :form, :h1, :h2, :h3, :h4, :h5, :h6, :head, :header, :hgroup, 
                        :hr, :html, :i, :iframe, :img, :input, :ins, :keygen, :kbd, :label, 
-                       :legend, :li, :link, :map, :mark, :menu, :menuitem, :meta, :meter, :nav, :noscript, 
+                       :legend, :li, :link, :main, :map, :mark, :menu, :menuitem, :meta, :meter, :nav, :noscript,
                        :object, :ol, :optgroup, :option, :output, :param, :pre, :progress, :q,
                        :s, :samp, :script, :section, :select, :small, :source, :span,
                        :strong, :style, :sub, :summary, :sup, :svg, :table, :tbody, :td,


### PR DESCRIPTION
From MDN:

> The HTML `<main>` element represents the dominant content of the <body> of a document. The main content area consists of content that is directly related to or expands upon the central topic of a document, or the central functionality of an application.

It's been in the spec [since 2012](https://lists.w3.org/Archives/Public/public-html/2012Nov/0232.html) and I'd love to improve the accessibility of ActiveAdmin by including it!