### PR TITLE
CI: Use latest JRuby 9.2.14.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [2.5.8, 2.6.6, 2.7.2, 3.0.0, jruby-9.2.11.1]
+        ruby: [2.5.8, 2.6.6, 2.7.2, 3.0.0, jruby-9.2.14.0]
 
     env:
       BUNDLE_PATH: vendor/bundle


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.14.0**.

[JRuby 9.2.14.0 release blog post](https://www.jruby.org/2020/12/08/jruby-9-2-14-0.html) ✨ 