### PR TITLE
Avoid mutating string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Metrics:
 
 Layout/HeredocIndentation:
   Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'http://rubygems.org'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'bundler'
 Bundler::GemHelper.install_tasks
 

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arbre/version"
 

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 gem 'github-pages'
 gem 'jekyll-redirect-from'

--- a/lib/arbre.rb
+++ b/lib/arbre.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_support/core_ext/string/output_safety'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/inflector'

--- a/lib/arbre/component.rb
+++ b/lib/arbre/component.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   class Component < Arbre::HTML::Div
 

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arbre/element'
 require 'ruby2_keywords'
 

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arbre/element/builder_methods'
 require 'arbre/element/proxy'
 require 'arbre/element_collection'

--- a/lib/arbre/element/builder_methods.rb
+++ b/lib/arbre/element/builder_methods.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   class Element
 

--- a/lib/arbre/element/proxy.rb
+++ b/lib/arbre/element/proxy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   class Element
     class Proxy < BasicObject

--- a/lib/arbre/element_collection.rb
+++ b/lib/arbre/element_collection.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
 
   # Stores a collection of Element objects

--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module HTML
 

--- a/lib/arbre/html/class_list.rb
+++ b/lib/arbre/html/class_list.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'set'
 
 module Arbre

--- a/lib/arbre/html/document.rb
+++ b/lib/arbre/html/document.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module HTML
 

--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module HTML
 

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -117,20 +117,24 @@ module Arbre
         spaces = ' ' * indent_level * INDENT_SIZE
 
         html = ""
+
         if no_child? || child_is_text?
           if self_closing_tag?
-            html += open_tag.sub(/>$/, '/>')
+            html += spaces + open_tag.sub( />$/, '/>' )
           else
             # one line
-            html += open_tag + child_content + close_tag
+            html += spaces + open_tag + child_content + close_tag
           end
         else
           # multiple lines
-          # the child takes care of its own spaces
-          html += open_tag + "\n" + child_content + spaces + close_tag
+          html += spaces + open_tag + "\n"
+          html += child_content # the child takes care of its own spaces
+          html += spaces + close_tag
         end
 
-        spaces + html + "\n"
+        html += "\n"
+
+        html
       end
 
       def self_closing_tag?

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'erb'
 
 module Arbre
@@ -115,25 +116,18 @@ module Arbre
       def indent(open_tag, child_content, close_tag)
         spaces = ' ' * indent_level * INDENT_SIZE
 
-        html = ""
-
-        if no_child? || child_is_text?
+        spaces + if no_child? || child_is_text?
           if self_closing_tag?
-            html << spaces << open_tag.sub( />$/, '/>' )
+            open_tag.sub( />$/, '/>' )
           else
             # one line
-            html << spaces << open_tag << child_content << close_tag
+            open_tag + child_content + close_tag
           end
         else
           # multiple lines
-          html << spaces << open_tag << "\n"
-          html << child_content # the child takes care of its own spaces
-          html << spaces << close_tag
-        end
-
-        html << "\n"
-
-        html
+          # the child takes care of its own spaces
+          open_tag + "\n" + child_content + spaces + close_tag
+        end + "\n"
       end
 
       def self_closing_tag?

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -116,18 +116,21 @@ module Arbre
       def indent(open_tag, child_content, close_tag)
         spaces = ' ' * indent_level * INDENT_SIZE
 
-        spaces + if no_child? || child_is_text?
+        html = ""
+        if no_child? || child_is_text?
           if self_closing_tag?
-            open_tag.sub( />$/, '/>' )
+            html += open_tag.sub(/>$/, '/>')
           else
             # one line
-            open_tag + child_content + close_tag
+            html += open_tag + child_content + close_tag
           end
         else
           # multiple lines
           # the child takes care of its own spaces
-          open_tag + "\n" + child_content + spaces + close_tag
-        end + "\n"
+          html += open_tag + "\n" + child_content + spaces + close_tag
+        end
+
+        spaces + html + "\n"
       end
 
       def self_closing_tag?

--- a/lib/arbre/html/text_node.rb
+++ b/lib/arbre/html/text_node.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'erb'
 
 module Arbre

--- a/lib/arbre/rails.rb
+++ b/lib/arbre/rails.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'arbre/rails/template_handler'
 require 'arbre/rails/forms'
 require 'arbre/rails/rendering'

--- a/lib/arbre/rails/forms.rb
+++ b/lib/arbre/rails/forms.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module Rails
     module Forms

--- a/lib/arbre/rails/rendering.rb
+++ b/lib/arbre/rails/rendering.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module Rails
     module Rendering

--- a/lib/arbre/rails/template_handler.rb
+++ b/lib/arbre/rails/template_handler.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   module Rails
     class TemplateHandler

--- a/lib/arbre/version.rb
+++ b/lib/arbre/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Arbre
   VERSION = "1.4.0"
 end

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre do

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 # A mock subclass to play with

--- a/spec/arbre/unit/context_spec.rb
+++ b/spec/arbre/unit/context_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::Context do

--- a/spec/arbre/unit/element_finder_methods_spec.rb
+++ b/spec/arbre/unit/element_finder_methods_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::Element, "Finder Methods" do

--- a/spec/arbre/unit/element_spec.rb
+++ b/spec/arbre/unit/element_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::Element do

--- a/spec/arbre/unit/html/class_list_spec.rb
+++ b/spec/arbre/unit/html/class_list_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::HTML::ClassList do

--- a/spec/arbre/unit/html/tag_attributes_spec.rb
+++ b/spec/arbre/unit/html/tag_attributes_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::HTML::Tag, "Attributes" do

--- a/spec/arbre/unit/html/tag_spec.rb
+++ b/spec/arbre/unit/html/tag_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::HTML::Tag do

--- a/spec/arbre/unit/html/text_node_spec.rb
+++ b/spec/arbre/unit/html/text_node_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe Arbre::HTML::TextNode do

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe "Changelog" do

--- a/spec/gemspec_spec.lint.rb
+++ b/spec/gemspec_spec.lint.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 require "arbre/version"
 

--- a/spec/rails/integration/forms_spec.rb
+++ b/spec/rails/integration/forms_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/rails_spec_helper'
 
 describe "Building forms" do

--- a/spec/rails/integration/rendering_spec.rb
+++ b/spec/rails/integration/rendering_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/rails_spec_helper'
 
 ARBRE_VIEWS_PATH = File.expand_path("../../templates", __FILE__)

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 require 'bundler/setup'
 

--- a/spec/rails/stub_app/config/routes.rb
+++ b/spec/rails/stub_app/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.routes.draw do
   #
 end

--- a/spec/rails/stub_app/db/schema.rb
+++ b/spec/rails/stub_app/db/schema.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # ActiveRecord::Schema.define do
 #   #
 # end

--- a/spec/rails/support/mock_person.rb
+++ b/spec/rails/support/mock_person.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'active_model'
 
 class MockPerson

--- a/spec/rails/templates/arbre/_partial.arb
+++ b/spec/rails/templates/arbre/_partial.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 para "Hello from a partial"

--- a/spec/rails/templates/arbre/_partial_with_assignment.arb
+++ b/spec/rails/templates/arbre/_partial_with_assignment.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 para "Partial: #{my_instance_var}"

--- a/spec/rails/templates/arbre/page_with_arb_partial_and_assignment.arb
+++ b/spec/rails/templates/arbre/page_with_arb_partial_and_assignment.arb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 h1 "Before Partial"
 render "arbre/partial_with_assignment"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/page_with_assignment.arb
+++ b/spec/rails/templates/arbre/page_with_assignment.arb
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 h1 my_instance_var

--- a/spec/rails/templates/arbre/page_with_erb_partial.arb
+++ b/spec/rails/templates/arbre/page_with_erb_partial.arb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 h1 "Before Partial"
 render "erb/partial"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/page_with_partial.arb
+++ b/spec/rails/templates/arbre/page_with_partial.arb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 h1 "Before Partial"
 render "arbre/partial"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/simple_page.arb
+++ b/spec/rails/templates/arbre/simple_page.arb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 html do
   head do
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'support/bundle'
 
 require 'arbre'

--- a/spec/support/bundle.rb
+++ b/spec/support/bundle.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 $LOAD_PATH.unshift(File.expand_path("../../", __FILE__))
 
 require "bundler"

--- a/tasks/lint.rake
+++ b/tasks/lint.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "open3"
 
 #

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "chandler/tasks"
 
 #


### PR DESCRIPTION
- Changes `indent` in `lib/arbre/html/tag.rb` to not mutate string literals
- Adds `Style/FrozenStringLiteralComment` to Rubocop rules so that string literal mutation is not accidentally added back