### PR TITLE
Drop support for Ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,10 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [2.5.9, 2.6.9, 2.7.5, 3.0.3, jruby-9.3.2.0]
+        ruby: [2.6.9, 2.7.5, 3.0.3, jruby-9.3.2.0]
         deps: [rails_61, rails_70]
 
         exclude:
-          - deps: rails_70
-            ruby: 2.5.9
           - deps: rails_70
             ruby: 2.6.9
           - deps: rails_70

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
 
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.6
 
 Metrics:
   Enabled: false

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.6'
 
   s.add_dependency("activesupport", ">= 3.0.0", "< 7.1")
   s.add_dependency("ruby2_keywords", ">= 0.0.2", "< 1.0")


### PR DESCRIPTION
Ruby 2.5 arrived to its EOL. As I was doing in other repositories of `activeadmin` organization, let's drop the support for this Ruby version.