### PR TITLE
Get rid of chandler gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,6 @@ group :tools do
   gem 'rubocop-packaging'
 end
 
-group :release do
-  gem 'chandler'
-end
-
 group :rails do
   gem 'rails', '~> 7.0.0'
   gem 'rspec-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chandler (0.9.0)
-      netrc
-      octokit (>= 2.2.0)
     coderay (1.1.3)
     combustion (1.3.5)
       activesupport (>= 3.0.0)
@@ -100,29 +97,6 @@ GEM
     digest (3.1.0)
     digest (3.1.0-java)
     erubi (1.10.0)
-    faraday (1.9.3)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.3)
-      multipart-post (>= 1.2, < 3)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
     ffi (1.15.5-java)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -140,7 +114,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
-    multipart-post (2.1.1)
     net-imap (0.2.3)
       digest
       net-protocol
@@ -156,7 +129,6 @@ GEM
       digest
       net-protocol
       timeout
-    netrc (0.11.0)
     nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.1)
@@ -164,9 +136,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-java)
       racc (~> 1.4)
-    octokit (4.22.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -249,9 +218,6 @@ GEM
       rubocop (>= 0.89, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sawyer (0.8.2)
-      addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
     spoon (0.0.6)
       ffi
     strscan (3.0.1)
@@ -276,7 +242,6 @@ PLATFORMS
 DEPENDENCIES
   arbre!
   capybara
-  chandler
   combustion
   pry
   rails (~> 7.0.0)

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,6 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 import 'tasks/lint.rake'
-import 'tasks/release.rake'
 
 task default: [:spec, :lint]
 

--- a/gemfiles/rails_61.gemfile
+++ b/gemfiles/rails_61.gemfile
@@ -13,10 +13,6 @@ group :tools do
   gem 'rubocop-packaging'
 end
 
-group :release do
-  gem 'chandler'
-end
-
 group :rails do
   gem 'rails', '~> 6.1.0'
   gem 'rspec-rails'

--- a/gemfiles/rails_61.gemfile.lock
+++ b/gemfiles/rails_61.gemfile.lock
@@ -80,9 +80,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    chandler (0.9.0)
-      netrc
-      octokit (>= 2.2.0)
     coderay (1.1.3)
     combustion (1.3.5)
       activesupport (>= 3.0.0)
@@ -92,25 +89,6 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     erubi (1.10.0)
-    faraday (1.8.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
-      ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
     ffi (1.15.4-java)
     globalid (1.0.0)
       activesupport (>= 5.0)
@@ -127,8 +105,6 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
     minitest (5.15.0)
-    multipart-post (2.1.1)
-    netrc (0.11.0)
     nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.1)
@@ -136,9 +112,6 @@ GEM
       racc (~> 1.4)
     nokogiri (1.13.1-java)
       racc (~> 1.4)
-    octokit (4.21.0)
-      faraday (>= 0.9)
-      sawyer (~> 0.8.0, >= 0.5.3)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
@@ -221,9 +194,6 @@ GEM
       rubocop (>= 0.89, < 2.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    sawyer (0.8.2)
-      addressable (>= 2.3.5)
-      faraday (> 0.8, < 2.0)
     spoon (0.0.6)
       ffi
     sprockets (4.0.2)
@@ -253,7 +223,6 @@ PLATFORMS
 DEPENDENCIES
   arbre!
   capybara
-  chandler
   combustion
   pry
   rails (~> 6.1.0)

--- a/tasks/release.rake
+++ b/tasks/release.rake
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-require "chandler/tasks"
-
-#
-# Add chandler as a prerequisite for `rake release`
-#
-task "release:rubygem_push" => "chandler:push"


### PR DESCRIPTION
`chandler` gem received its last update almost 3 years ago and nowadays is archived, so, unmaintained. Github has some tools for creating release notes automatically.

The same than here: https://github.com/activeadmin/inherited_resources/pull/713