### PR TITLE
Remove Ruby 2.6.9 from mergify.yml

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -5,7 +5,6 @@ pull_request_rules:
 
     conditions:
       - author~=^dependabot\[bot\]$
-      - check-success=test (2.6.9, rails_61)
       - check-success=test (2.7.5, rails_61)
       - check-success=test (2.7.5, rails_70)
       - check-success=test (3.0.3, rails_61)


### PR DESCRIPTION
When doing this PR https://github.com/activeadmin/arbre/pull/345 looks like I missed to remove Ruby 2.6 from `mergify.yml`