### PR TITLE
Stop testing on JRuby

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -11,7 +11,6 @@ pull_request_rules:
       - check-success=test (3.0.3, rails_70)
       - check-success=test (3.1.0, rails_61)
       - check-success=test (3.1.0, rails_70)
-      - check-success=test (jruby-9.3.2.0, rails_61)
 
     actions:
       merge:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        ruby: [2.7.5, 3.0.3, 3.1.0, jruby-9.3.2.0]
+        ruby: [2.7.5, 3.0.3, 3.1.0]
         deps: [rails_61, rails_70]
-
-        exclude:
-          - deps: rails_70
-            ruby: jruby-9.3.2.0
 
     steps:
       - uses: actions/checkout@v2

--- a/spec/gemspec_spec.lint.rb
+++ b/spec/gemspec_spec.lint.rb
@@ -14,21 +14,7 @@ RSpec.describe "gemspec sanity" do
   end
 
   it "has no warnings" do
-    output = build[1]
-
-    if RUBY_ENGINE == "jruby"
-      annoying_jruby_warnings = [
-        /WARNING: An illegal reflective access operation has occurred/,
-        /WARNING: Illegal reflective access by org.jruby.ext.openssl.SecurityHelper \(file:.*\/jopenssl\.jar\) to field java\.security\.MessageDigest\.provider/,
-        /WARNING: Please consider reporting this to the maintainers of org\.jruby\.ext\.openssl\.SecurityHelper/,
-        /WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations/,
-        /WARNING: All illegal access operations will be denied in a future release/
-      ]
-
-      output = output.split("\n").reject { |line| annoying_jruby_warnings.any? { |warning| warning.match?(line) } }.join("\n")
-    end
-
-    expect(output).not_to include("WARNING"), output
+    expect(build[1]).not_to include("WARNING"), output
   end
 
   it "succeeds" do


### PR DESCRIPTION
We dropped Ruby 2.6 support, and JRuby does not yet have any releases
compatible with more modern rubies