### PR TITLE
Lazy-load rails interactions

### DIFF
--- a/lib/arbre.rb
+++ b/lib/arbre.rb
@@ -17,5 +17,5 @@ require 'arbre/html/html5_elements'
 require 'arbre/component'
 
 if defined?(Rails)
-  require 'arbre/rails'
+  require 'arbre/railtie'
 end

--- a/lib/arbre/rails.rb
+++ b/lib/arbre/rails.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-require 'arbre/rails/template_handler'
-require 'arbre/rails/forms'
-require 'arbre/rails/rendering'
-
-Arbre::Element.send :include, Arbre::Rails::Rendering

--- a/lib/arbre/rails/rendering.rb
+++ b/lib/arbre/rails/rendering.rb
@@ -12,7 +12,6 @@ module Arbre
           text_node rendered
         end
       end
-
     end
   end
 end

--- a/lib/arbre/rails/template_handler.rb
+++ b/lib/arbre/rails/template_handler.rb
@@ -14,5 +14,3 @@ module Arbre
     end
   end
 end
-
-ActionView::Template.register_template_handler :arb, Arbre::Rails::TemplateHandler.new

--- a/lib/arbre/railtie.rb
+++ b/lib/arbre/railtie.rb
@@ -4,6 +4,8 @@ require 'arbre/rails/forms'
 require 'arbre/rails/rendering'
 require 'rails'
 
+Arbre::Element.include(Arbre::Rails::Rendering)
+
 module Arbre
   class Railtie < ::Rails::Railtie
     initializer "arbre" do

--- a/lib/arbre/railtie.rb
+++ b/lib/arbre/railtie.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'arbre/rails/template_handler'
+require 'arbre/rails/forms'
+require 'arbre/rails/rendering'
+require 'rails'
+
+module Arbre
+  class Railtie < ::Rails::Railtie
+    initializer "arbre" do
+      ActiveSupport.on_load(:action_view) do
+        ActionView::Template.register_template_handler :arb, Arbre::Rails::TemplateHandler.new
+      end
+    end
+  end
+end

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -33,8 +33,8 @@ end
 
 def mock_action_view(assigns = {})
   controller = ActionView::TestCase::TestController.new
-  ActionView::Base.send :include, ActionView::Helpers
-  ActionView::Base.send :include, AdditionalHelpers
+  ActionView::Base.include(ActionView::Helpers)
+  ActionView::Base.include(AdditionalHelpers)
   context = ActionView::LookupContext.new(ActionController::Base.view_paths)
   ActionView::Base.new(context, assigns, controller)
 end

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -4,6 +4,9 @@ require 'bundler/setup'
 
 require 'combustion'
 
+# Ensure that the rails plugin is installed
+require 'arbre/railtie'
+
 Combustion.path = 'spec/rails/stub_app'
 Combustion.initialize! :action_controller,
                        :action_view
@@ -15,9 +18,6 @@ require 'capybara/rails'
 require 'spec_helper'
 
 require 'rails/support/mock_person'
-
-# Ensure that the rails plugin is installed
-require 'arbre/rails'
 
 module AdditionalHelpers
 

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
-require 'rubygems'
-require 'bundler/setup'
 
-require 'combustion'
-
-# Ensure that the rails plugin is installed
-require 'arbre/railtie'
+require 'spec_helper'
 
 Combustion.path = 'spec/rails/stub_app'
 Combustion.initialize! :action_controller,
@@ -14,8 +9,6 @@ Combustion.initialize! :action_controller,
 require 'rspec/rails'
 require 'capybara/rspec'
 require 'capybara/rails'
-
-require 'spec_helper'
 
 require 'rails/support/mock_person'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ if ENV.fetch('COVERAGE', false)
 end
 
 require 'support/bundle'
+require 'combustion'
 require 'arbre'
 
 def arbre(&block)


### PR DESCRIPTION
Thus PR does a few things:
- Rename `lib/rails.rb` to `lib/railtie.rb` to follow modern conventions.
- Register a Railtie and add an arbre initializer that listens for `action_view` loading. Only then do we want to register the template handler.
- Change all `send :include` to just `include` since this gem supports only version of Ruby where it’s a public method.

The way it's current done is problematic for me because it attempts to reference `ActionView` before it's loaded by the application itself (`config/application.rb`). Requiring the `rails` gem doesn't actually load _all_ the rails gems.