### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
+  s.metadata = { "rubygems_mfa_required" => "true" }
+
   s.required_ruby_version = '>= 2.7'
 
   s.add_dependency("activesupport", ">= 3.0.0", "< 7.1")


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/