### PR TITLE
Add Dependabot review workflow for auto merge

### DIFF
--- a/.github/workflows/dependabot-review.yml
+++ b/.github/workflows/dependabot-review.yml
@@ -1,0 +1,39 @@
+name: Dependabot Review
+
+on:
+  pull_request_target:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot-pr-review:
+    name: Approve Dependabot PR
+    runs-on: ubuntu-latest
+    if: ${{ vars.SKIP_DEPENDABOT_REVIEW != 'true' && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR_NUM: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: dependabot/fetch-metadata@v1
+        id: dependabot-metadata
+      - name: Enable auto-merge for this Dependabot PR
+        run: gh pr merge --auto --squash "$PR_NUM"
+      - name: Approve patch and minor updates
+        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr review "$PR_NUM" --approve --body "Approving this patch or minor update."
+        # - name: Approve major updates of development dependencies
+        #   if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.dependency-type == 'direct:development' }}
+        #   run: gh pr review $PR_URL --approve --body "Approving this major update of a dependency used only in development."
+        #   env:
+        #     PR_URL: ${{github.event.pull_request.html_url}}
+        #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        # - name: Comment on major updates of non-development dependencies
+        #   if: ${{steps.dependabot-metadata.outputs.update-type == 'version-update:semver-major' && steps.dependabot-metadata.outputs.dependency-type == 'direct:production'}}
+        #   run: |
+        #     gh pr comment $PR_URL --body "I'm **not approving** this PR because **it includes a major update of a dependency used in production**"
+        #     gh pr edit $PR_URL --add-label "requires-manual-qa"
+        #   env:
+        #     PR_URL: ${{github.event.pull_request.html_url}}
+        #     GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This should replace our mergify setup and the need to duplicate our PR checks in mergify's config file when we don't want too.