### PR TITLE
issue 474: fix kwarg deprecation warning for method_missing method in…

### DIFF
--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -174,13 +174,13 @@ module Arbre
     #  3. Call the method on the helper object
     #  4. Call super
     #
-    ruby2_keywords def method_missing(name, *args, &block)
+    ruby2_keywords def method_missing(name, *args, **kwargs, &block)
       if current_arbre_element.respond_to?(name)
-        current_arbre_element.send name, *args, &block
+        current_arbre_element.send name, *args, **kwargs, &block
       elsif assigns && assigns.has_key?(name)
         assigns[name]
       elsif helpers.respond_to?(name)
-        helpers.send(name, *args, &block)
+        helpers.send(name, *args, **kwargs, &block)
       else
         super
       end


### PR DESCRIPTION
Resolves the deprecation warning seen here:

```
gems/arbre-1.5.0/lib/arbre/element.rb:183: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

Fixes the same potential issue on line 179 as well.

See Issue #474 