### PR TITLE
Include blank attributes in HTML output

### DIFF
--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -6,13 +6,12 @@ module Arbre
 
       def to_s
         flatten_hash.map do |name, value|
-          next if value_empty?(value)
-          "#{html_escape(name)}=\"#{html_escape(value)}\""
-        end.compact.join ' '
-      end
-
-      def any?
-        super{ |k,v| !value_empty?(v) }
+          if value.nil?
+            html_escape(name)
+          else
+            "#{html_escape(name)}=\"#{html_escape(value)}\""
+          end
+        end.join ' '
       end
 
       protected
@@ -27,10 +26,6 @@ module Arbre
           end
         end
         accumulator
-      end
-
-      def value_empty?(value)
-        value.respond_to?(:empty?) ? value.empty? : !value
       end
 
       def html_escape(s)

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -150,7 +150,7 @@ module Arbre
       end
 
       def attributes_html
-        " #{attributes}" if attributes.any?
+        attributes.any? ? " " + attributes.to_s : nil
       end
 
       def set_for_attribute(record)

--- a/spec/arbre/unit/html/tag_attributes_spec.rb
+++ b/spec/arbre/unit/html/tag_attributes_spec.rb
@@ -18,12 +18,12 @@ describe Arbre::HTML::Tag, "Attributes" do
         expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
       end
 
-      it "shouldn't render attributes that are empty" do
+      it "should still render attributes that are empty" do
         tag.class_list # initializes an empty ClassList
         tag.set_attribute :foo, ''
         tag.set_attribute :bar, nil
 
-        expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
+        expect(tag.to_s).to eq "<tag id=\"my_id\" class=\"\" foo=\"\" bar></tag>\n"
       end
 
       context "with hyphenated attributes" do
@@ -41,12 +41,12 @@ describe Arbre::HTML::Tag, "Attributes" do
           expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
         end
 
-        it "shouldn't render attributes that are empty" do
+        it "should still render attributes that are empty" do
           tag.class_list # initializes an empty ClassList
           tag.set_attribute :foo, { bar: '' }
           tag.set_attribute :bar, { baz: nil }
 
-          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
+          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\" class=\"\" foo-bar=\"\" bar-baz></tag>\n"
         end
       end
 


### PR DESCRIPTION
This is mostly a full revert of commit 15267891a4c741154c7ee601d86851b16516588a which was a bad change. Empty attributes are valid HTML (e.g. boolean attributes) and should be supported here. The bad commit was for just addressing the class attribute but that applied to any attribute in HTML when it shouldn't have, even for just class. 

With this change, the generated HTML string is improved:

```ruby
tag = Arbre::HTML::Tag.new
tag.build disabled: nil, required: "", class: "blue"
tag.to_s
=> "<tag disabled required=\"\" class=\"blue\"></tag>\n"
```

Prior to this change, the output for that would have been:

```
=> "<tag class=\"blue\"></tag>\n"
```

This PR and #516 will be in a major (v2) release due to possible breaking change.
