### PR TITLE
Prep for v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Master (unreleased)
+## 2.0.0 [☰](https://github.com/activeadmin/arbre/compare/v1.7.0...v2.0.0)
+
+* Include empty attributes in HTML output. [#543][] by [@javierjulio][]
+* Remove table tag defaults. [#542][] by [@javierjulio][]
+* Remove component CSS class name default. [#545][] by [@javierjulio][]
 
 ## 1.7.0 [☰](https://github.com/activeadmin/arbre/compare/v1.6.0...v1.7.0)
 
@@ -127,6 +131,9 @@ Initial release and extraction from Active Admin
 [#456]: https://github.com/activeadmin/arbre/pull/456
 [#537]: https://github.com/activeadmin/arbre/pull/537
 [#539]: https://github.com/activeadmin/arbre/pull/539
+[#542]: https://github.com/activeadmin/arbre/pull/542
+[#543]: https://github.com/activeadmin/arbre/pull/543
+[#545]: https://github.com/activeadmin/arbre/pull/545
 
 [@aramvisser]: https://github.com/aramvisser
 [@LTe]: https://github.com/LTe

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    arbre (1.7.0)
+    arbre (2.0.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
 

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    arbre (1.7.0)
+    arbre (2.0.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
 

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../..
   specs:
-    arbre (1.7.0)
+    arbre (2.0.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
 

--- a/lib/arbre/version.rb
+++ b/lib/arbre/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Arbre
-  VERSION = "1.7.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
This is on hold for any other possible changes to include but primarily as we begin the next major release of ActiveAdmin (v5) that will require Arbre v2+ for the breaking changes in #542, #543 and #545.