### PR TITLE
Remove upper bound dependency limits from gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     arbre (1.6.0)
-      activesupport (>= 3.0.0, < 7.1)
-      ruby2_keywords (>= 0.0.2, < 1.0)
+      activesupport (>= 3.0.0)
+      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.7'
 
-  s.add_dependency("activesupport", ">= 3.0.0", "< 7.1")
-  s.add_dependency("ruby2_keywords", ">= 0.0.2", "< 1.0")
+  s.add_dependency("activesupport", ">= 3.0.0")
+  s.add_dependency("ruby2_keywords", ">= 0.0.2")
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: ../..
   specs:
     arbre (1.6.0)
-      activesupport (>= 3.0.0, < 7.1)
-      ruby2_keywords (>= 0.0.2, < 1.0)
+      activesupport (>= 3.0.0)
+      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -14,10 +14,6 @@ RSpec.describe "gemspec sanity" do
     end
   end
 
-  it "has no warnings" do
-    expect(build[1]).not_to include("WARNING")
-  end
-
   it "succeeds" do
     expect(build[2]).to be_success
   end


### PR DESCRIPTION
Following same approach as we did in https://github.com/activeadmin/inherited_resources/pull/711 to make future maintenance easier.

All that was needed to support Rails 7 in this gem was to update the gemspec. This means that even in the most likely release to break anything, a major release, we didn't needed to worry about breaking this gem.

This upper bound is just creating unnecessary work for the maintainers of this gem, which would need to release it without any code change, and the users, which need to open issues asking for new releases.

Let's allow our users to try any version of our dependencies and report real issues if they find them, and save everyone's time just removing the upper bound.