### PR TITLE
Revert "Remove table tag defaults (#516)"

### DIFF
--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -28,5 +28,21 @@ module Arbre
       builder_method :para
     end
 
+    class Table < Tag
+      def initialize(*)
+        super
+        set_table_tag_defaults
+      end
+
+      protected
+
+      # Set some good defaults for tables
+      def set_table_tag_defaults
+        set_attribute :border,      0
+        set_attribute :cellspacing, 0
+        set_attribute :cellpadding, 0
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This reverts commit 186106dcf7a83662ff3680a28731e765d0885f78.

This is a temporary revert to allow us to create another v1 release from master branch which was switched to v2 with this and #517 which we want to redo anyway.