### PR TITLE
Revert "Include blank attributes in HTML output (#517)"

### DIFF
--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -6,12 +6,13 @@ module Arbre
 
       def to_s
         flatten_hash.map do |name, value|
-          if value.nil?
-            html_escape(name)
-          else
-            "#{html_escape(name)}=\"#{html_escape(value)}\""
-          end
-        end.join ' '
+          next if value_empty?(value)
+          "#{html_escape(name)}=\"#{html_escape(value)}\""
+        end.compact.join ' '
+      end
+
+      def any?
+        super{ |k,v| !value_empty?(v) }
       end
 
       protected
@@ -26,6 +27,10 @@ module Arbre
           end
         end
         accumulator
+      end
+
+      def value_empty?(value)
+        value.respond_to?(:empty?) ? value.empty? : !value
       end
 
       def html_escape(s)

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -150,7 +150,7 @@ module Arbre
       end
 
       def attributes_html
-        attributes.any? ? " " + attributes.to_s : nil
+        " #{attributes}" if attributes.any?
       end
 
       def set_for_attribute(record)

--- a/spec/arbre/unit/html/tag_attributes_spec.rb
+++ b/spec/arbre/unit/html/tag_attributes_spec.rb
@@ -18,12 +18,12 @@ describe Arbre::HTML::Tag, "Attributes" do
         expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
       end
 
-      it "should still render attributes that are empty" do
+      it "shouldn't render attributes that are empty" do
         tag.class_list # initializes an empty ClassList
         tag.set_attribute :foo, ''
         tag.set_attribute :bar, nil
 
-        expect(tag.to_s).to eq "<tag id=\"my_id\" class=\"\" foo=\"\" bar></tag>\n"
+        expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
       end
 
       context "with hyphenated attributes" do
@@ -41,12 +41,12 @@ describe Arbre::HTML::Tag, "Attributes" do
           expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
         end
 
-        it "should still render attributes that are empty" do
+        it "shouldn't render attributes that are empty" do
           tag.class_list # initializes an empty ClassList
           tag.set_attribute :foo, { bar: '' }
           tag.set_attribute :bar, { baz: nil }
 
-          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\" class=\"\" foo-bar=\"\" bar-baz></tag>\n"
+          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
         end
       end
 


### PR DESCRIPTION
This reverts commit cf59b8ff98eaff99d0f05b0cacc948b422c03073.

This is a temporary revert to allow us to create another v1 release from master branch which was switched to v2. We want to redo this change anyway.