### PR TITLE
Remove table tag defaults

### DIFF
--- a/lib/arbre/html/html5_elements.rb
+++ b/lib/arbre/html/html5_elements.rb
@@ -28,21 +28,5 @@ module Arbre
       builder_method :para
     end
 
-    class Table < Tag
-      def initialize(*)
-        super
-        set_table_tag_defaults
-      end
-
-      protected
-
-      # Set some good defaults for tables
-      def set_table_tag_defaults
-        set_attribute :border,      0
-        set_attribute :cellspacing, 0
-        set_attribute :cellpadding, 0
-      end
-    end
-
   end
 end


### PR DESCRIPTION
These are unnecessary for a long time now as they can be controlled easily through CSS. It would be best to have no overrides for these elements (other p/para due to the name clash).

This will be in a major (v2) release due to being a breaking change.