### PR TITLE
Include empty attributes in HTML output

### DIFF
--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -5,14 +5,9 @@ module Arbre
     class Attributes < Hash
 
       def to_s
-        flatten_hash.map do |name, value|
-          next if value_empty?(value)
+        flatten_hash.compact.map do |name, value|
           "#{html_escape(name)}=\"#{html_escape(value)}\""
         end.compact.join ' '
-      end
-
-      def any?
-        super{ |k,v| !value_empty?(v) }
       end
 
       protected
@@ -27,10 +22,6 @@ module Arbre
           end
         end
         accumulator
-      end
-
-      def value_empty?(value)
-        value.respond_to?(:empty?) ? value.empty? : !value
       end
 
       def html_escape(s)

--- a/spec/arbre/unit/html/tag_attributes_spec.rb
+++ b/spec/arbre/unit/html/tag_attributes_spec.rb
@@ -18,12 +18,12 @@ describe Arbre::HTML::Tag, "Attributes" do
         expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
       end
 
-      it "shouldn't render attributes that are empty" do
+      it "should still render attributes that are empty but not nil" do
         tag.class_list # initializes an empty ClassList
         tag.set_attribute :foo, ''
         tag.set_attribute :bar, nil
 
-        expect(tag.to_s).to eq "<tag id=\"my_id\"></tag>\n"
+        expect(tag.to_s).to eq "<tag id=\"my_id\" class=\"\" foo=\"\"></tag>\n"
       end
 
       context "with hyphenated attributes" do
@@ -41,17 +41,17 @@ describe Arbre::HTML::Tag, "Attributes" do
           expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
         end
 
-        it "shouldn't render attributes that are empty" do
+        it "should still render attributes that are empty but not nil" do
           tag.class_list # initializes an empty ClassList
           tag.set_attribute :foo, { bar: '' }
           tag.set_attribute :bar, { baz: nil }
 
-          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\"></tag>\n"
+          expect(tag.to_s).to eq "<tag id=\"my_id\" data-action=\"some_action\" class=\"\" foo-bar=\"\"></tag>\n"
         end
       end
 
       context "when there is a deeply nested attribute" do
-        before { tag.build id: "my_id", foo: { bar: { baz: 'foozle' } } }
+        before { tag.build id: "my_id", foo: { bar: { bat: nil, baz: 'foozle' } } }
 
         it "should flatten the attributes when rendering to html" do
           expect(tag.to_s).to eq "<tag id=\"my_id\" foo-bar-baz=\"foozle\"></tag>\n"
@@ -59,10 +59,10 @@ describe Arbre::HTML::Tag, "Attributes" do
       end
 
       context "when there are multiple nested attributes" do
-        before { tag.build id: "my_id", foo: { bar: 'foozle1', baz: 'foozle2' } }
+        before { tag.build id: "my_id", foo: { bar: 'foozle1', bat: nil, baz: '' } }
 
         it "should flatten the attributes when rendering to html" do
-          expect(tag.to_s).to eq "<tag id=\"my_id\" foo-bar=\"foozle1\" foo-baz=\"foozle2\"></tag>\n"
+          expect(tag.to_s).to eq "<tag id=\"my_id\" foo-bar=\"foozle1\" foo-baz=\"\"></tag>\n"
         end
       end
     end


### PR DESCRIPTION
This is mostly a full revert of commit 1526789 which was a bad change. Empty attributes are valid HTML (e.g. boolean attributes) and should be supported in Arbre. The bad commit was for just addressing the class attribute but that applied to any attribute in HTML when it shouldn't have, even for just class. Note that if an attribute value is `nil` then it is removed. This follows same output logic to the Rails `tag.attributes` helper method.

With this change, the generated HTML string is improved:

```ruby
tag = Arbre::HTML::Tag.new
tag.build disabled: nil, required: "", class: "blue"
tag.to_s
=> "<tag required=\"\" class=\"blue\"></tag>\n"
```

Prior to this change, the output for that would have been:

```
=> "<tag class=\"blue\"></tag>\n"
```

This will be in a major (v2) release due to being a breaking change.
