### PR TITLE
Remove component CSS class name default

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,7 @@ This provides a simpler alternative to nesting partials.
 The recommended approach is to subclass Arbre::Component and implement a new builder method.
 
 The builder_method defines the method that will be called to build this component
-when using the DSL. The arguments passed into the builder_method will be passed 
+when using the DSL. The arguments passed into the builder_method will be passed
 into the #build method for you.
 
 For example:
@@ -66,7 +66,7 @@ class Panel < Arbre::Component
 end
 ```
 
-By default components are `div` tags with an HTML class corresponding to the component class name.  This can be overridden by redefining the `tag_name` method.
+By default, components are `div` tags. This can be overridden by redefining the `tag_name` method.
 
 Several examples of Arbre components are [included in Active Admin](https://activeadmin.info/12-arbre-components.html)
 
@@ -76,7 +76,7 @@ An [Arbre::Context](http://www.rubydoc.info/gems/arbre/Arbre/Context) is an obje
 
 ```ruby
 html = Arbre::Context.new do
-  panel "Hello World", id: "my-panel" do
+  panel "Hello World", class: "panel", id: "my-panel" do
     span "Inside the panel"
     text_node "Plain text"
   end

--- a/lib/arbre/component.rb
+++ b/lib/arbre/component.rb
@@ -1,23 +1,9 @@
 # frozen_string_literal: true
 module Arbre
   class Component < Arbre::HTML::Div
-
     # By default components render a div
     def tag_name
       'div'
     end
-
-    def initialize(*)
-      super
-      add_class default_class_name
-    end
-
-    protected
-
-    # By default, add a css class named after the ruby class
-    def default_class_name
-      self.class.name.demodulize.underscore
-    end
-
   end
 end

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -13,12 +13,10 @@ class MockComponent < Arbre::Component
 end
 
 describe Arbre::Component do
-
   let(:assigns) { {} }
   let(:helpers) { nil }
-
-  let(:component_class){ MockComponent }
-  let(:component){ component_class.new }
+  let(:component_class) { MockComponent }
+  let(:component) { component_class.new }
 
   it "should be a subclass of an html div" do
     expect(Arbre::Component.ancestors).to include(Arbre::HTML::Div)
@@ -28,18 +26,18 @@ describe Arbre::Component do
     expect(component.tag_name).to eq('div')
   end
 
-  it "should add a class by default" do
-    expect(component.class_list).to include("mock_component")
+  it "should not have a class list" do
+    expect(component.class_list.to_s).to eq("")
+    expect(component.class_list.empty?).to eq(true)
   end
 
   it "should render the object using the builder method name" do
     comp = expect(arbre {
       mock_component
     }.to_s).to eq <<~HTML
-      <div class="mock_component">
+      <div>
         <h2>Hello World</h2>
       </div>
       HTML
   end
-
 end


### PR DESCRIPTION
A component will no longer add a CSS class name by default.

This will be in a major (v2) release due to being a breaking change.