### PR TITLE
Fix RuboCop Layout and Style configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,16 +50,37 @@ Capybara/VisibilityMatcher:
 Metrics:
   Enabled: false
 
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
 Layout/ExtraSpacing:
   Enabled: true
 
 Layout/HeredocIndentation:
   Enabled: true
 
-Layout/TrailingEmptyLines:
+Layout/IndentationConsistency:
+  Enabled: true
+
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/IndentationStyle:
   Enabled: true
 
 Layout/TrailingWhitespace:
+  Enabled: true
+
+Layout/TrailingEmptyLines:
   Enabled: true
 
 Performance:
@@ -539,3 +560,6 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:
     - bin/console
+
+Style/HashSyntax:
+  Enabled: true

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -26,7 +26,6 @@ module Arbre
   #     html.to_s #=> "Your number 1"
   #
   class Context < Element
-
     # Initialize a new Arbre::Context
     #
     # @param [Hash] assigns A hash of objecs that you would like to be
@@ -98,7 +97,6 @@ module Arbre
 
     private
 
-
     # Caches the rendered HTML so that we don't re-render just to
     # get the content length or to delegate a method to the HTML
     def cached_html
@@ -110,6 +108,5 @@ module Arbre
         html
       end
     end
-
   end
 end

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -185,6 +185,5 @@ module Arbre
         super
       end
     end
-
   end
 end

--- a/lib/arbre/element/builder_methods.rb
+++ b/lib/arbre/element/builder_methods.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 module Arbre
   class Element
-
     module BuilderMethods
 
       def self.included(klass)
@@ -78,6 +77,5 @@ module Arbre
 
       end
     end
-
   end
 end

--- a/lib/arbre/element_collection.rb
+++ b/lib/arbre/element_collection.rb
@@ -3,7 +3,6 @@ module Arbre
 
   # Stores a collection of Element objects
   class ElementCollection < Array
-
     def +(other)
       self.class.new(super)
     end

--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -3,7 +3,6 @@ module Arbre
   module HTML
 
     class Attributes < Hash
-
       def to_s
         flatten_hash.compact.map do |name, value|
           "#{html_escape(name)}=\"#{html_escape(value)}\""

--- a/lib/arbre/html/class_list.rb
+++ b/lib/arbre/html/class_list.rb
@@ -6,7 +6,6 @@ module Arbre
 
     # Holds a set of classes
     class ClassList < Set
-
       def self.build_from_string(class_names)
         new.add(class_names)
       end
@@ -22,7 +21,6 @@ module Arbre
       def to_s
         to_a.join(" ")
       end
-
     end
 
   end

--- a/lib/arbre/html/document.rb
+++ b/lib/arbre/html/document.rb
@@ -3,7 +3,6 @@ module Arbre
   module HTML
 
     class Document < Tag
-
       def build(*args)
         super
         build_head
@@ -30,7 +29,7 @@ module Arbre
 
       def build_head
         @head = head do
-          meta :"http-equiv" => "Content-type", content: "text/html; charset=utf-8"
+          meta "http-equiv": "Content-type", content: "text/html; charset=utf-8"
         end
       end
 

--- a/lib/arbre/html/tag.rb
+++ b/lib/arbre/html/tag.rb
@@ -184,7 +184,6 @@ module Arbre
       def default_id_for_prefix
         nil
       end
-
     end
 
   end

--- a/lib/arbre/html/text_node.rb
+++ b/lib/arbre/html/text_node.rb
@@ -5,7 +5,6 @@ module Arbre
   module HTML
 
     class TextNode < Element
-
       builder_method :text_node
 
       # Builds a text node from a string

--- a/lib/arbre/rails/forms.rb
+++ b/lib/arbre/rails/forms.rb
@@ -38,7 +38,6 @@ module Arbre
             super
           end
         end
-
       end
 
       class FormForProxy < FormBuilderProxy
@@ -70,11 +69,9 @@ module Arbre
         def closing_tag
           @closing_tag || ""
         end
-
       end
 
       class FieldsForProxy < FormBuilderProxy
-
         def build(form_builder, *args, &block)
           form_builder.fields_for(*args) do |f|
             @form_builder = f
@@ -86,7 +83,6 @@ module Arbre
         def to_s
           children.to_s
         end
-
       end
 
     end

--- a/spec/arbre/integration/html_spec.rb
+++ b/spec/arbre/integration/html_spec.rb
@@ -74,7 +74,6 @@ describe Arbre do
     HTML
   end
 
-
   it "passes the element in to the block if asked for" do
     expect(arbre {
       div do |d|
@@ -90,7 +89,6 @@ describe Arbre do
       </div>
     HTML
   end
-
 
   it "moves content tags between parents" do
     expect(arbre {

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -3,13 +3,11 @@ require 'spec_helper'
 
 # A mock subclass to play with
 class MockComponent < Arbre::Component
-
   builder_method :mock_component
 
   def build
     h2 "Hello World"
   end
-
 end
 
 describe Arbre::Component do

--- a/spec/arbre/unit/html/document_spec.rb
+++ b/spec/arbre/unit/html/document_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe Arbre::HTML::Document do
+  let(:document){ described_class.new }
+
+  describe "#to_s" do
+    subject { document.to_s }
+
+    before do
+      document.build
+    end
+
+    it { is_expected.to eq "<!DOCTYPE html><html></html>\n" }
+  end
+end

--- a/spec/arbre/unit/html/tag_spec.rb
+++ b/spec/arbre/unit/html/tag_spec.rb
@@ -36,7 +36,6 @@ describe Arbre::HTML::Tag do
       expect(tag.class_list).to include("resource_class")
     end
 
-
     describe "for an object that doesn't have a model_name" do
       let(:resource_class){ double(name: 'ResourceClass') } # rubocop:disable RSpec/VerifiedDoubles
 

--- a/spec/changelog_spec.rb
+++ b/spec/changelog_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe "Changelog" do
 
     let(:lines) { changelog.each_line }
 
-
     it 'does not end with a punctuation' do
       entries.each do |entry|
         expect(entry).not_to match(/\.$/)

--- a/spec/rails/integration/forms_spec.rb
+++ b/spec/rails/integration/forms_spec.rb
@@ -102,5 +102,4 @@ RSpec.describe "Forms" do
     end
   end
 
-
 end


### PR DESCRIPTION
Add the missing options to `Layout` and `Style` departments.

Using the configuration from `inherited_resources`

---

Please review with "Hide whitespace" option enabled

<img width="758" alt="image" src="https://github.com/activeadmin/arbre/assets/556268/62be83b0-a99a-43fc-b295-24795d7d0550">
