### PR TITLE
Remove unnecessary `.compact` call

### DIFF
--- a/lib/arbre/html/attributes.rb
+++ b/lib/arbre/html/attributes.rb
@@ -6,7 +6,7 @@ module Arbre
       def to_s
         flatten_hash.compact.map do |name, value|
           "#{html_escape(name)}=\"#{html_escape(value)}\""
-        end.compact.join ' '
+        end.join ' '
       end
 
       protected


### PR DESCRIPTION
The `.compact` method is used to remove nil elements from an array. However, in this context, it is unnecessary because the `.map` operation is already creating an array of strings, and there's no `nil` values that could be removed