### PR TITLE
Drop dependency on ruby2_keywords

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     arbre (2.0.0)
       activesupport (>= 3.0.0)
-      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
 
   s.add_dependency("activesupport", ">= 3.0.0")
-  s.add_dependency("ruby2_keywords", ">= 0.0.2")
 end

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     arbre (2.0.0)
       activesupport (>= 3.0.0)
-      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -191,7 +190,6 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     arbre (2.0.0)
       activesupport (>= 3.0.0)
-      ruby2_keywords (>= 0.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -197,7 +196,6 @@ GEM
       rspec-mocks (~> 3.12)
       rspec-support (~> 3.12)
     rspec-support (3.12.1)
-    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require 'arbre/element'
-require 'ruby2_keywords'
 
 module Arbre
 

--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -2,7 +2,6 @@
 require 'arbre/element/builder_methods'
 require 'arbre/element/proxy'
 require 'arbre/element_collection'
-require 'ruby2_keywords'
 
 module Arbre
 


### PR DESCRIPTION
Now that Ruby < 2.7 is not supported (#345) this isn't needed anymore