### PR TITLE
Remove redundant encoding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -565,6 +565,9 @@ RSpec/VoidExpect:
 RSpec/Yield:
   Enabled: true
 
+Style/Encoding:
+  Enabled: true
+
 Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:

--- a/arbre.gemspec
+++ b/arbre.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # frozen_string_literal: true
 $:.push File.expand_path("../lib", __FILE__)
 require "arbre/version"

--- a/spec/arbre/unit/context_spec.rb
+++ b/spec/arbre/unit/context_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 require 'spec_helper'
 


### PR DESCRIPTION
This magic comment is not needed anymore because the default encoding of source code files assumed by Ruby 2 is utf-8, and the minimum required Ruby version is 2.7

Autofixed with:
```
rubocop -a
```