### PR TITLE
Fix RuboCop Packaging configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,18 @@ Layout/TrailingWhitespace:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+Packaging/BundlerSetupInTests:
+  Enabled: true
+
+Packaging/GemspecGit:
+  Enabled: true
+
+Packaging/RequireHardcodingLib:
+  Enabled: true
+
+Packaging/RequireRelativeHardcodingLib:
+  Enabled: true
+
 Performance:
   Enabled: true
 


### PR DESCRIPTION
Parity with activeadmin and inherited_resources