### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/arbre.rb
+++ b/lib/arbre.rb
@@ -6,16 +6,16 @@ require 'active_support/inflector'
 module Arbre
 end
 
-require 'arbre/element'
-require 'arbre/context'
-require 'arbre/html/attributes'
-require 'arbre/html/class_list'
-require 'arbre/html/tag'
-require 'arbre/html/text_node'
-require 'arbre/html/document'
-require 'arbre/html/html5_elements'
-require 'arbre/component'
+require_relative 'arbre/element'
+require_relative 'arbre/context'
+require_relative 'arbre/html/attributes'
+require_relative 'arbre/html/class_list'
+require_relative 'arbre/html/tag'
+require_relative 'arbre/html/text_node'
+require_relative 'arbre/html/document'
+require_relative 'arbre/html/html5_elements'
+require_relative 'arbre/component'
 
 if defined?(Rails)
-  require 'arbre/railtie'
+  require_relative 'arbre/railtie'
 end

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'arbre/element'
+require_relative 'element'
 
 module Arbre
 

--- a/lib/arbre/railtie.rb
+++ b/lib/arbre/railtie.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'arbre/rails/template_handler'
-require 'arbre/rails/forms'
-require 'arbre/rails/rendering'
+require_relative 'rails/template_handler'
+require_relative 'rails/forms'
+require_relative 'rails/rendering'
 require 'rails'
 
 Arbre::Element.include(Arbre::Rails::Rendering)


### PR DESCRIPTION
Hi @deivid-rodriguez, I ran into an issue that you are probably familiar with while experimenting with [GemBench](https://github.com/pboling/gem_bench)

If you think this is a good change, I'll do the same for inherited_resources

---

`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- ruby/psych#522
- ruby/logger#20
- ruby/rdoc#658
- panorama-ed/memo_wise#349
- rubocop/rubocop#8748