### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,4 +25,7 @@ group :rails do
   gem 'rspec-rails'
   gem 'combustion'
   gem 'capybara'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -298,6 +298,7 @@ DEPENDENCIES
   rubocop-rspec
   simplecov
   simplecov-cobertura
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_61/Gemfile
+++ b/gemfiles/rails_61/Gemfile
@@ -15,6 +15,9 @@ group :rails do
   gem 'rspec-rails'
   gem 'combustion'
   gem 'capybara'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 gemspec path: "../.."

--- a/gemfiles/rails_61/Gemfile.lock
+++ b/gemfiles/rails_61/Gemfile.lock
@@ -233,6 +233,7 @@ DEPENDENCIES
   rspec-rails
   simplecov
   simplecov-cobertura
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_70/Gemfile
+++ b/gemfiles/rails_70/Gemfile
@@ -15,6 +15,9 @@ group :rails do
   gem 'rspec-rails'
   gem 'combustion'
   gem 'capybara'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 gemspec path: "../.."

--- a/gemfiles/rails_70/Gemfile.lock
+++ b/gemfiles/rails_70/Gemfile.lock
@@ -232,6 +232,7 @@ DEPENDENCIES
   rspec-rails
   simplecov
   simplecov-cobertura
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21

--- a/gemfiles/rails_71/Gemfile
+++ b/gemfiles/rails_71/Gemfile
@@ -15,6 +15,9 @@ group :rails do
   gem 'rspec-rails'
   gem 'combustion'
   gem 'capybara'
+
+  # FIXME: relax this dependency when Ruby 3.1 support will be dropped
+  gem "zeitwerk", "~> 2.6.18"
 end
 
 gemspec path: "../.."

--- a/gemfiles/rails_71/Gemfile.lock
+++ b/gemfiles/rails_71/Gemfile.lock
@@ -264,6 +264,7 @@ DEPENDENCIES
   rspec-rails
   simplecov
   simplecov-cobertura
+  zeitwerk (~> 2.6.18)
 
 BUNDLED WITH
-   2.5.19
+   2.5.21


### PR DESCRIPTION
Pin zeitwerk to `~> 2.6.18` because 2.7.0 only supports Ruby >= 3.2