### PR TITLE
Fix spec warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -584,6 +584,7 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:
     - bin/console
+    - '**/*.arb'
 
 Style/HashSyntax:
   Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,15 @@ Layout/TrailingWhitespace:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
 Packaging/BundlerSetupInTests:
   Enabled: true
 

--- a/spec/arbre/unit/component_spec.rb
+++ b/spec/arbre/unit/component_spec.rb
@@ -30,7 +30,7 @@ describe Arbre::Component do
   end
 
   it "renders the object using the builder method name" do
-    comp = expect(arbre {
+    expect(arbre {
       mock_component
     }.to_s).to eq <<~HTML
       <div>

--- a/spec/rails/templates/arbre/_partial.arb
+++ b/spec/rails/templates/arbre/_partial.arb
@@ -1,2 +1,1 @@
-# frozen_string_literal: true
 para "Hello from a partial"

--- a/spec/rails/templates/arbre/_partial_with_assignment.arb
+++ b/spec/rails/templates/arbre/_partial_with_assignment.arb
@@ -1,2 +1,1 @@
-# frozen_string_literal: true
 para "Partial: #{my_instance_var}"

--- a/spec/rails/templates/arbre/page_with_arb_partial_and_assignment.arb
+++ b/spec/rails/templates/arbre/page_with_arb_partial_and_assignment.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 h1 "Before Partial"
 render "arbre/partial_with_assignment"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/page_with_assignment.arb
+++ b/spec/rails/templates/arbre/page_with_assignment.arb
@@ -1,2 +1,1 @@
-# frozen_string_literal: true
 h1 my_instance_var

--- a/spec/rails/templates/arbre/page_with_erb_partial.arb
+++ b/spec/rails/templates/arbre/page_with_erb_partial.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 h1 "Before Partial"
 render "erb/partial"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/page_with_partial.arb
+++ b/spec/rails/templates/arbre/page_with_partial.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 h1 "Before Partial"
 render "arbre/partial"
 h2 "After Partial"

--- a/spec/rails/templates/arbre/page_with_render_with_block.arb
+++ b/spec/rails/templates/arbre/page_with_render_with_block.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 render_in_object = Class.new do
   def render_in(_, &block)
     block.call

--- a/spec/rails/templates/arbre/simple_page.arb
+++ b/spec/rails/templates/arbre/simple_page.arb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 html do
   head do
   end


### PR DESCRIPTION
## Fix unassigned variable warning

Fix `warning: assigned but unused variable - comp` warning

## Remove frozen string literals from arb templates 

It does not have effect there and outputs a warning when running tests
with `RUBYOPTS='-w' rake`

```
warning: 'frozen_string_literal' is ignored after any tokens
```

Behavior tested in `empty.arb` template

```
# frozen_string_literal: true
hello = 'hello'
hello.concat ' world'
```

Expected: fail
Actual: pass

Close #649