### PR TITLE
Enable `Lint/AmbiguousOperator` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -86,6 +86,9 @@ Layout/TrailingWhitespace:
 Layout/TrailingEmptyLines:
   Enabled: true
 
+Lint/AmbiguousOperator:
+  Enabled: true
+
 Packaging/BundlerSetupInTests:
   Enabled: true
 


### PR DESCRIPTION
Parity with ActiveAdmin to prevent introduction of new warnings

Ref: activeadmin/activeadmin#8594