### PR TITLE
Remove `.arb` exclusion on frozen string literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -599,7 +599,6 @@ Style/FrozenStringLiteralComment:
   Enabled: true
   Exclude:
     - bin/console
-    - '**/*.arb'
 
 Style/HashSyntax:
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
     rspec-support (3.13.2)
-    rubocop (1.70.0)
+    rubocop (1.71.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)


### PR DESCRIPTION
This was a false positive fixed in rubocop/rubocop#13699