### PR TITLE
Ensure Arbre context is reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased [☰](https://github.com/activeadmin/arbre/compare/v2.2.0...master)
+
+* Ensure Arbre context is properly reset after rendering [#700][] by [@drcapulet][]
+
 ## 2.2.0 [☰](https://github.com/activeadmin/arbre/compare/v2.1.0...v2.2.0)
 
 * Add some missing HTML5 elements [#655][] by [@tagliala][]
@@ -159,6 +163,7 @@ Initial release and extraction from Active Admin
 [#622]: https://github.com/activeadmin/arbre/pull/622
 [#644]: https://github.com/activeadmin/arbre/pull/644
 [#655]: https://github.com/activeadmin/arbre/pull/655
+[#700]: https://github.com/activeadmin/arbre/pull/700
 
 [@aramvisser]: https://github.com/aramvisser
 [@LTe]: https://github.com/LTe
@@ -184,3 +189,4 @@ Initial release and extraction from Active Admin
 [@javierjulio]: https://github.com/javierjulio
 [@Earlopain]: https://github.com/Earlopain
 [@budu]: https://github.com/budu
+[@drcapulet]: https://github.com/drcapulet

--- a/lib/arbre/context.rb
+++ b/lib/arbre/context.rb
@@ -90,6 +90,7 @@ module Arbre
       raise ArgumentError, "Can't be in the context of nil. #{@_current_arbre_element_buffer.inspect}" unless tag
       @_current_arbre_element_buffer.push tag
       yield
+    ensure
       @_current_arbre_element_buffer.pop
     end
     alias_method :within, :with_current_arbre_element

--- a/spec/arbre/unit/context_spec.rb
+++ b/spec/arbre/unit/context_spec.rb
@@ -32,4 +32,24 @@ describe Arbre::Context do
     expect(context.index('<')).to eq(0)
   end
 
+  context "when an error is raised in a nested block" do
+    let(:context) do
+      described_class.new do
+        ul do
+          li do
+            'item one'
+          end
+          li do
+            raise 'error talking to the db'
+          end
+        end
+      rescue StandardError
+        para 'Uh oh! DB call failed'
+      end
+    end
+
+    it "properly resets the element buffer" do
+      expect(context.current_arbre_element).to be_a(described_class)
+    end
+  end
 end


### PR DESCRIPTION
When you have an Arbre component with a block form, it pushes the current node onto a stack so that it can use [method_missing][1] to provide a dynamic evaluation context (eg. so tab is available only directly inside of tabs).

Unfortunately, when an error is raised inside inside one of these, if we have a rescue to catch that error so the rest of the page can be rendered - the context is still stuck inside the last block that was added. Other than likely rendering some of the wrong markup (depending on usage), it means the context is not put back into the block where the rescue is located. As a result, even though that block is effectively thrown away when a rescue is located above the erroring call, certain features are not available.

[1]: https://github.com/activeadmin/arbre/blob/v2.2.0/lib/arbre/element.rb#L176-L186