### PR TITLE
Support autoloading for custom Arbre components 

### DIFF
--- a/lib/arbre/element.rb
+++ b/lib/arbre/element.rb
@@ -174,7 +174,9 @@ module Arbre
     #  4. Call super
     #
     ruby2_keywords def method_missing(name, *args, &block)
-      if current_arbre_element.respond_to?(name)
+      if "Arbre::Components::#{name.to_s.camelize}".safe_constantize && respond_to?(name)
+        public_send(name, *args, &block)
+      elsif current_arbre_element.respond_to?(name)
         current_arbre_element.send name, *args, &block
       elsif assigns && assigns.has_key?(name)
         assigns[name]

--- a/spec/rails/integration/rendering_spec.rb
+++ b/spec/rails/integration/rendering_spec.rb
@@ -27,6 +27,10 @@ class TestController < ActionController::Base
     render "arbre/page_with_assignment"
   end
 
+  def render_with_autoloadable_component
+    render "arbre/page_with_autoloadable_component"
+  end
+
   def render_partial_with_instance_variable
     @my_instance_var = "From Instance Var"
     render "arbre/page_with_arb_partial_and_assignment"
@@ -47,6 +51,7 @@ RSpec.describe TestController, "Rendering with Arbre", type: :request do
       get 'test/render_partial', controller: "test"
       get 'test/render_erb_partial', controller: "test"
       get 'test/render_with_instance_variable', controller: "test"
+      get 'test/render_with_autoloadable_component', controller: "test"
       get 'test/render_partial_with_instance_variable', controller: "test"
       get 'test/render_page_with_helpers', controller: "test"
       get 'test/render_with_block', controller: "test"
@@ -93,6 +98,12 @@ RSpec.describe TestController, "Rendering with Arbre", type: :request do
     get "/test/render_with_instance_variable"
     expect(response).to be_successful
     expect(body).to have_css("h1", text: "From Instance Var")
+  end
+
+  it "renders with autoloadable component" do
+    get "/test/render_with_autoloadable_component"
+    expect(response).to be_successful
+    expect(body).to have_css("div", text: "Autoloadable Component")
   end
 
   it "renders an arbre partial with assignments" do

--- a/spec/rails/rails_spec_helper.rb
+++ b/spec/rails/rails_spec_helper.rb
@@ -6,6 +6,7 @@ Combustion.initialize! :action_controller, :action_view do
   if Rails.gem_version >= Gem::Version.new("7.1.0")
     config.active_support.cache_format_version = 7.1
   end
+  config.autoload_paths << "#{root}/services"
 end
 
 require 'rspec/rails'

--- a/spec/rails/stub_app/services/arbre/components/autoloadable_component.rb
+++ b/spec/rails/stub_app/services/arbre/components/autoloadable_component.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+class Arbre::Components::AutoloadableComponent < Arbre::Component
+  builder_method :autoloadable_component
+
+  def build
+    div "Autoloadable Component"
+  end
+end

--- a/spec/rails/templates/arbre/page_with_autoloadable_component.arb
+++ b/spec/rails/templates/arbre/page_with_autoloadable_component.arb
@@ -1,0 +1,1 @@
+autoloadable_component


### PR DESCRIPTION
We recently added this patch to our Rails app, so I figured I'd open a PR to see if you'd want to consider upstreaming it into Arbre.

## Motivation 

Our dilemma is that we have a bunch of custom Arbre components that we use in our admin app. Since you use Arbre components by their declared "builder_method" name, and not by referencing the class, they don't play well with zeitwerk/autoloading. This means you either need to:
- Force all usages to `require` the right arbre component manually
- More likely, add some sort of initializer to just require them all on app boot

We did the latter, and it was starting to become costly toward boot time since these components inevitably wound up pulling more things into memory. It's also wasteful since these components are only ever used in our admin app, but then they'd load on any app boot (e.g. rspec, rails console, background jobs, etc). You can obviously work around these things, but the beauty of Rails autoloading means you don't have to.

## Solution 

This PR makes it possible to autoload these components by introducing a simple convention: a component named `foo_bar`, is defined by a class named `Arbre::Components::FooBar` that's on some autoload path. This approach intentionally doesn't support deeper namespacing (e.g. `Arbre::Components::Foo::Bar`) since:
- "builder_method" names don't have any namespacing, everything is global.
- Allowing namespacing means two classes in different namespaces could have the same name, which means they’d register the same builder method. To my knowledge, nothing in the Arbre gem prevents this (maybe it should?), but at least this convention helps to prevent it.

I've updated the test suite to configure autoloading and added a test that fails before this change and passes after. Happy to help update documentation or whatever else, but first wanted to just put up this PR to see if it's even something you'd consider.